### PR TITLE
use bcrypt, add a pyshop-user response header.

### DIFF
--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -220,7 +220,7 @@ class User(Base):
         user = cls.by_login(session, login, local=True)
         if not user:
             return None
-        if bcrypt.checkpw(user.password, password.encode('utf8')):
+        if bcrypt.checkpw(user.password, bcrypt.hashpw(password.encode('utf8'), bcrypt.gensalt(12)):
             return user
 
     @classmethod

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -167,7 +167,7 @@ class User(Base):
         return self._password
 
     def _set_password(self, password):
-        self._password = unicode(bcrypt.hashpw(password, bcrypt.gensalt(12)))
+        self._password = unicode(bcrypt.hashpw(password.encode('utf8'), bcrypt.gensalt(12)))
 
     password = property(_get_password, _set_password)
     password = synonym('_password', descriptor=password)
@@ -220,7 +220,7 @@ class User(Base):
         user = cls.by_login(session, login, local=True)
         if not user:
             return None
-        if bcrypt.checkpw(user.password, password):
+        if bcrypt.checkpw(user.password, password.encode('utf8')):
             return user
 
     @classmethod

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -16,7 +16,7 @@ except ImportError:
     ldap = None
 from pyramid.settings import asbool
 
-import cryptacular.bcrypt
+import bcrypt
 import transaction
 from pkg_resources import parse_version
 
@@ -35,7 +35,6 @@ from .helpers.sqla import (Database, SessionFactory, ModelError,
 
 
 log = logging.getLogger(__name__)
-crypt = cryptacular.bcrypt.BCRYPTPasswordManager()
 
 re_email = re.compile(r'^[^@]+@[a-z0-9]+[-.a-z0-9]+\.[a-z]+$', re.I)
 
@@ -168,7 +167,7 @@ class User(Base):
         return self._password
 
     def _set_password(self, password):
-        self._password = unicode(crypt.encode(password))
+        self._password = unicode(bcrypt.hashpw(password, bcrypt.gensalt(12)))
 
     password = property(_get_password, _set_password)
     password = synonym('_password', descriptor=password)
@@ -221,7 +220,7 @@ class User(Base):
         user = cls.by_login(session, login, local=True)
         if not user:
             return None
-        if crypt.check(user.password, password):
+        if bcrypt.checkpw(user.password, password):
             return user
 
     @classmethod

--- a/pyshop/models.py
+++ b/pyshop/models.py
@@ -166,8 +166,13 @@ class User(Base):
     def _get_password(self):
         return self._password
 
+    @classmethod
+    def hash_password(cls, pw):
+        return bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt(12))
+
     def _set_password(self, password):
-        self._password = unicode(bcrypt.hashpw(password.encode('utf8'), bcrypt.gensalt(12)))
+        # we want to store this in the database as unicode
+        self._password = unicode(hashpw(password))
 
     password = property(_get_password, _set_password)
     password = synonym('_password', descriptor=password)
@@ -220,7 +225,7 @@ class User(Base):
         user = cls.by_login(session, login, local=True)
         if not user:
             return None
-        if bcrypt.checkpw(user.password, bcrypt.hashpw(password.encode('utf8'), bcrypt.gensalt(12)):
+        if bcrypt.checkpw(password.encode('utf8'), user.password.encode('utf8')):
             return user
 
     @classmethod

--- a/pyshop/views/base.py
+++ b/pyshop/views/base.py
@@ -43,6 +43,8 @@ class ViewBase(object):
         try:
             log.info('dispatch view %s', self.__class__.__name__)
             response = self.render()
+            if 'headers' in response:
+                response.headers['X-Pyshop-User'] = self.login
             self.update_response(response)
             # if isinstance(response, dict):
             #     log.info("rendering template with context %r", dict)

--- a/pyshop/views/base.py
+++ b/pyshop/views/base.py
@@ -32,6 +32,8 @@ class ViewBase(object):
         else:
             self.login = u'anonymous'
             self.user = None
+        if hasattr(self.request, 'response') and hasattr(self.request.response, 'headers'):
+            self.request.response.headers['X-Pyshop-User'] = str(self.login)
 
     def update_response(self, response):
         pass
@@ -43,8 +45,6 @@ class ViewBase(object):
         try:
             log.info('dispatch view %s', self.__class__.__name__)
             response = self.render()
-            if 'headers' in response:
-                response.headers['X-Pyshop-User'] = self.login
             self.update_response(response)
             # if isinstance(response, dict):
             #     log.info("rendering template with context %r", dict)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requires = [
     'pyramid_tm',
     'zope.sqlalchemy',
 
-    'cryptacular',
+    'bcrypt',
     'requests',
     'docutils',
     'setuptools',            # compare package version


### PR DESCRIPTION
A while ago, cryptacular got updated in a way that I couldn't get the C bits to build in our environment so i ported it to pure-python bcrypt.  

This also adds a custom HTTP response header that I can scrape with uWSGI to see who is actually using our pyshop.